### PR TITLE
Scheduling and limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     implementation 'io.projectreactor.addons:reactor-extra'
 

--- a/src/main/java/no/fint/drosjeloyve/configuration/OrganisationProperties.java
+++ b/src/main/java/no/fint/drosjeloyve/configuration/OrganisationProperties.java
@@ -20,5 +20,6 @@ public class OrganisationProperties {
         private boolean deviationPolicy;
         private String skjermingshjemmel;
         private String tilgangsrestriksjon;
+        private int limit;
     }
 }


### PR DESCRIPTION
This PR adds Cron scheduling and a per-organization limit of number of applications to process per invocation.

Scheduling is now controlled by `scheduling.cron`, and organization properties has a new property `limit` which, if greater than zero, is used as a limiter.